### PR TITLE
Added scaling for SVG's

### DIFF
--- a/lib/output.mustache
+++ b/lib/output.mustache
@@ -1,5 +1,7 @@
 .icon {
+	display: inline-block;
 	background-repeat: no-repeat;
+	background-size: contain;
 
 	{{#items}}
 	&.icon-{{slug}} {


### PR DESCRIPTION
Giving it a background-size: contain fixes a lot of scaling issues when rendering 1 SVG and using it in variable sizes.